### PR TITLE
Reverted to 1.0 until comms can be sorted

### DIFF
--- a/Shared/app-service.json
+++ b/Shared/app-service.json
@@ -67,7 +67,7 @@
                 "siteConfig": {
                     "appSettings": "[variables('appServiceSettings')]",
                     "alwaysOn": false,
-                    "minTlsVersion": "1.2"
+                    "minTlsVersion": "1.0"
                 }
             },
             "resources": [
@@ -84,7 +84,7 @@
                         "siteConfig": {
                             "appSettings": "[variables('appServiceSettings')]",
                             "alwaysOn": false,
-                            "minTlsVersion": "1.2"
+                            "minTlsVersion": "1.0"
                         }
                     },
                     "dependsOn": [


### PR DESCRIPTION
Reverted to 1.0 until the support team have comms to be able to support IE9 & 10 users correctly