### PR TITLE
Removed EP FW config

### DIFF
--- a/Shared/azure-sql.json
+++ b/Shared/azure-sql.json
@@ -26,12 +26,6 @@
         "description": "The name of the SQL Elastic Pool"
       }
     },
-    "EPGWIP": {
-      "type": "string",
-      "metadata": {
-        "description": "Firewall IP"
-      }
-    },
     "CHGWIP": {
       "type": "string",
       "metadata": {
@@ -65,19 +59,6 @@
           "properties": {
             "endIpAddress": "[parameters('CHGWIP')]",
             "startIpAddress": "[parameters('CHGWIP')]"
-          }
-        },
-        {
-          "type": "firewallRules",
-          "apiVersion": "2014-04-01",
-          "dependsOn": [
-            "[parameters('sqlserverName')]"
-          ],
-          "location": "[resourceGroup().location]",
-          "name": "EPGWIP",
-          "properties": {
-            "endIpAddress": "[parameters('EPGWIP')]",
-            "startIpAddress": "[parameters('EPGWIP')]"
           }
         },
         {

--- a/Shared/parameters.json
+++ b/Shared/parameters.json
@@ -60,9 +60,6 @@
         "CHGWIP": {
             "value": "__CHGWIP__"
         },
-        "EPGWIP": {
-            "value": "__EPGWIP__"
-        },
         "postgresServerName": {
             "value": "__postgresServerName__"
         },


### PR DESCRIPTION
No longer using EP as a building and therefore the WIFI IP address is no longer needed on the FW rules.