### PR TITLE
Update azure-cdn-endpoint.json

### DIFF
--- a/Shared/azure-cdn-endpoint.json
+++ b/Shared/azure-cdn-endpoint.json
@@ -43,7 +43,7 @@
             "name": "[variables('fullEndpointName')]",
             "location": "[resourceGroup().location]",
             "properties": {
-                "isHttpAllowed": true,
+                "isHttpAllowed": false,
                 "isHttpsAllowed": true,
                 "origins": [
                     {


### PR DESCRIPTION
Removed option to connect over HTTP thus forcing HTTPS