### PR TITLE
Nsa 2569 node version setting

### DIFF
--- a/Shared/app-service.json
+++ b/Shared/app-service.json
@@ -91,7 +91,6 @@
                 "clientAffinityEnabled": false,
                 "httpsOnly": true,
                 "siteConfig": {
-                    "appSettings": "[variables('appServiceSettings')]",
                     "alwaysOn": true,
                     "minTlsVersion": "[parameters('minTlsVersion')]",
                     "numberOfWorkers": "[parameters('numberOfWorkers')]"

--- a/Shared/app-service.json
+++ b/Shared/app-service.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appServiceName": {
@@ -78,7 +78,20 @@
                 "value": "[parameters('appServiceConfigPath')]"
             }
         ],
-        "useCustomHostname": "[greater(length(parameters('customHostname')), 0)]"
+        "useCustomHostname": "[greater(length(parameters('customHostname')), 0)]",
+        "siteConfigSettings": {
+          "withAppServiceSettings": {
+            "appSettings": "[variables('appServiceSettings')]",
+            "alwaysOn": true,
+            "minTlsVersion": "[parameters('minTlsVersion')]",
+            "numberOfWorkers": "[parameters('numberOfWorkers')]"
+          },
+          "withoutAppServiceSettings": {
+            "alwaysOn": true,
+            "minTlsVersion": "[parameters('minTlsVersion')]",
+            "numberOfWorkers": "[parameters('numberOfWorkers')]"
+          }
+        }
     },
     "resources": [
         {
@@ -90,11 +103,7 @@
                 "serverFarmId": "[variables('appServicePlanId')]",
                 "clientAffinityEnabled": false,
                 "httpsOnly": true,
-                "siteConfig": {
-                    "alwaysOn": true,
-                    "minTlsVersion": "[parameters('minTlsVersion')]",
-                    "numberOfWorkers": "[parameters('numberOfWorkers')]"
-                }
+                "siteConfig": "[if(parameters('includeDeploymentSlot'), variables('siteConfigSettings').withoutAppServiceSettings, variables('siteConfigSettings').withAppServiceSettings)]"
             },
             "resources": [
                 {
@@ -107,12 +116,7 @@
                         "serverFarmId": "[variables('appServicePlanId')]",
                         "clientAffinityEnabled": false,
                         "httpsOnly": true,
-                        "siteConfig": {
-                            "appSettings": "[variables('appServiceSettings')]",
-                            "alwaysOn": false,
-                            "minTlsVersion": "[parameters('minTlsVersion')]",
-                            "numberOfWorkers": "[parameters('numberOfWorkers')]"
-                        }
+                        "siteConfig": "[variables('siteConfigSettings').withAppServiceSettings]"
                     },
                     "dependsOn": [
                         "[parameters('appServiceName')]"


### PR DESCRIPTION
Fixes the issue where the prod and staging slot app settings are being updated at the same time. This was highlighted during the Node.js update where the prod and staging slots were both update to 10.14.1 together.

Makes the following changes:

1. When the ARM template is run we should only update the app settings in the staging slot. These are swapped to the production slot later in the release process after a healthcheck is completed.

2. If we are not using a staging slot (includeDeploymentSlot = $false) then update the production slot app settings.