### PR TITLE
Feature/make elastic pool optional

### DIFF
--- a/Shared/database.json
+++ b/Shared/database.json
@@ -37,7 +37,17 @@
       "metadata": {
         "description": "The maximum size of the database in bytes"
       }
+    },
+    "individualDatabaseSku": {
+      "type": "object",
+      "defaultValue": "",
+      "metadata": {
+        "description": "If provided the database will be deployed outside of the Elastic Pool with the specified Service Tier"
+      }
     }
+  },
+  "variables": {
+    "elasticPoolName": "[if(empty(parameters('individualDatabaseSku')),parameters('elasticPoolName'),json('null'))]"
   },
   "resources": [
     {
@@ -51,8 +61,9 @@
       "properties": {
         "collation": "SQL_Latin1_General_CP1_CI_AS",
         "maxSizeBytes": "[parameters('databaseMaxSizeBytes')]",
-        "elasticPoolName": "[parameters('elasticPoolName')]"
+        "elasticPoolName": "[variables('elasticPoolName')]"
       },
+      "sku": "[parameters('individualDatabaseSku')]",
       "resources": [
         {
           "comments": "Transparent Data Encryption",

--- a/Shared/database.json
+++ b/Shared/database.json
@@ -57,6 +57,10 @@
         "collation": "SQL_Latin1_General_CP1_CI_AS",
         "maxSizeBytes": "[parameters('databaseMaxSizeBytes')]"
       }
+    },
+    "databaseSku": {
+      "name": "[parameters('individualDatabaseSku').name]",
+      "tier": "[parameters('individualDatabaseSku').tier]"
     }
   },
   "resources": [
@@ -69,7 +73,7 @@
       },
       "apiVersion": "2014-04-01",
       "properties": "[if(empty(parameters('individualDatabaseSku')), variables('databaseProperties').elasticPoolDatabase, variables('databaseProperties').standardDatabase)]",
-      "sku": "[if(empty(parameters('individualDatabaseSku')),json('null'), parameters('individualDatabaseSku'))]",
+      "sku": "[if(empty(parameters('individualDatabaseSku')),json('null'), variables('databaseSku'))]",
       "resources": [
         {
           "comments": "Transparent Data Encryption",

--- a/Shared/database.json
+++ b/Shared/database.json
@@ -38,7 +38,7 @@
         "description": "The maximum size of the database in bytes"
       }
     },
-    "individualDatabaseSku": {
+    "databaseSku": {
       "type": "object",
       "defaultValue": "",
       "metadata": {
@@ -47,6 +47,7 @@
     }
   },
   "variables": {
+    "isElasticDatabase": "[equals(parameters('databaseSku').name,'ElasticPool')]",
     "databaseProperties": {
       "elasticPoolDatabase": {
         "collation": "SQL_Latin1_General_CP1_CI_AS",
@@ -57,10 +58,6 @@
         "collation": "SQL_Latin1_General_CP1_CI_AS",
         "maxSizeBytes": "[parameters('databaseMaxSizeBytes')]"
       }
-    },
-    "databaseSku": {
-      "name": "[parameters('individualDatabaseSku').name]",
-      "tier": "[parameters('individualDatabaseSku').tier]"
     }
   },
   "resources": [
@@ -72,8 +69,8 @@
         "displayName": "Database"
       },
       "apiVersion": "2014-04-01",
-      "properties": "[if(empty(parameters('individualDatabaseSku')), variables('databaseProperties').elasticPoolDatabase, variables('databaseProperties').standardDatabase)]",
-      "sku": "[if(empty(parameters('individualDatabaseSku')),json('null'), variables('databaseSku'))]",
+      "properties": "[if(variables('isElasticDatabase'), variables('databaseProperties').elasticPoolDatabase, variables('databaseProperties').standardDatabase)]",
+      "sku": "[parameters('databaseSku')]",
       "resources": [
         {
           "comments": "Transparent Data Encryption",

--- a/Shared/database.json
+++ b/Shared/database.json
@@ -40,7 +40,10 @@
     },
     "databaseSku": {
       "type": "object",
-      "defaultValue": "",
+      "defaultValue": {
+        "name": "ElasticPool",
+        "tier": "Standard"
+      },
       "metadata": {
         "description": "If provided the database will be deployed outside of the Elastic Pool with the specified Service Tier"
       }
@@ -52,7 +55,7 @@
       "elasticPoolDatabase": {
         "collation": "SQL_Latin1_General_CP1_CI_AS",
         "maxSizeBytes": "[parameters('databaseMaxSizeBytes')]",
-        "elasticPoolName": "[parameters('elasticPoolName')]"
+        "elasticPoolId": "[resourceId('Microsoft.Sql/servers/elasticpools',parameters('sqlserverName'),parameters('elasticPoolName'))]"
       },
       "standardDatabase": {
         "collation": "SQL_Latin1_General_CP1_CI_AS",
@@ -68,7 +71,7 @@
       "tags": {
         "displayName": "Database"
       },
-      "apiVersion": "2014-04-01",
+      "apiVersion": "2017-10-01-preview",
       "properties": "[if(variables('isElasticDatabase'), variables('databaseProperties').elasticPoolDatabase, variables('databaseProperties').standardDatabase)]",
       "sku": "[parameters('databaseSku')]",
       "resources": [

--- a/Shared/database.json
+++ b/Shared/database.json
@@ -47,7 +47,17 @@
     }
   },
   "variables": {
-    "elasticPoolName": "[if(empty(parameters('individualDatabaseSku')),parameters('elasticPoolName'),json('null'))]"
+    "databaseProperties": {
+      "elasticPoolDatabase": {
+        "collation": "SQL_Latin1_General_CP1_CI_AS",
+        "maxSizeBytes": "[parameters('databaseMaxSizeBytes')]",
+        "elasticPoolName": "[parameters('elasticPoolName')]"
+      },
+      "standardDatabase": {
+        "collation": "SQL_Latin1_General_CP1_CI_AS",
+        "maxSizeBytes": "[parameters('databaseMaxSizeBytes')]"
+      }
+    }
   },
   "resources": [
     {
@@ -58,12 +68,8 @@
         "displayName": "Database"
       },
       "apiVersion": "2014-04-01",
-      "properties": {
-        "collation": "SQL_Latin1_General_CP1_CI_AS",
-        "maxSizeBytes": "[parameters('databaseMaxSizeBytes')]",
-        "elasticPoolName": "[variables('elasticPoolName')]"
-      },
-      "sku": "[parameters('individualDatabaseSku')]",
+      "properties": "[if(empty(parameters('individualDatabaseSku')), variables('databaseProperties').elasticPoolDatabase, variables('databaseProperties').standardDatabase)]",
+      "sku": "[if(empty(parameters('individualDatabaseSku')),json('null'), parameters('individualDatabaseSku'))]",
       "resources": [
         {
           "comments": "Transparent Data Encryption",

--- a/Shared/shared.template.json
+++ b/Shared/shared.template.json
@@ -348,7 +348,7 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2019-07-01",
       "name": "RedisCache",
       "type": "Microsoft.Resources/deployments",
       "properties": {

--- a/Shared/shared.template.json
+++ b/Shared/shared.template.json
@@ -348,7 +348,7 @@
       }
     },
     {
-      "apiVersion": "2018-03-01",
+      "apiVersion": "2017-05-10",
       "name": "RedisCache",
       "type": "Microsoft.Resources/deployments",
       "properties": {

--- a/Shared/shared.template.json
+++ b/Shared/shared.template.json
@@ -422,8 +422,8 @@
           "databaseMaxSizeBytes": {
             "value": "[parameters('databaseNames')[copyIndex()].maxSizeBytes]"
           },
-          "individualDatabaseSku": {
-            "value": "[if(empty(parameters('databaseNames')[copyIndex()].sku),json('null'),parameters('databaseNames')[copyIndex()].sku)]"
+          "databaseSku": {
+            "value": "[parameters('databaseNames')[copyIndex()].sku]"
           }
         }
       },

--- a/Shared/shared.template.json
+++ b/Shared/shared.template.json
@@ -421,6 +421,9 @@
           },
           "databaseMaxSizeBytes": {
             "value": "[parameters('databaseNames')[copyIndex()].maxSizeBytes]"
+          },
+          "individualDatabaseSku": {
+            "value": "[if(empty(parameters('databaseNames')[copyIndex()].sku),json('null'),parameters('databaseNames')[copyIndex()].sku)]"
           }
         }
       },


### PR DESCRIPTION
- Adds the ability to specify whether a database is inside or outside the pool. It has been tested with standard tier SKU's.
- Also fixed the API version of the Redis deployment in the shared template as it was not valid.

The databaseNames variable needs the sku adding. So the current production variable will change from:

```
[{
	"name": "$(AuditDBName)",
	"maxSizeBytes": "268435456000"
}, {
	"name": "$(DevicesDBName)",
	"maxSizeBytes": "5368709120"
}, {
	"name": "$(DirectoriesDBName)",
	"maxSizeBytes": "5368709120"
}, {
	"name": "$(JobsDBName)",
	"maxSizeBytes": "5368709120"
}, {
	"name": "$(OrganisationsDBName)",
	"maxSizeBytes": "5368709120"
}]
```

to:

```
[{
	"name": "$(AuditDBName)",
	"maxSizeBytes": "268435456000",
	"sku": {
		"name": "S12",
		"tier": "Standard"
	}
}, {
	"name": "$(DevicesDBName)",
	"maxSizeBytes": "5368709120",
	"sku": {
		"name": "ElasticPool",
		"tier": "Standard"
	}
}, {
	"name": "$(DirectoriesDBName)",
	"maxSizeBytes": "5368709120",
	"sku": {
		"name": "ElasticPool",
		"tier": "Standard"
	}
}, {
	"name": "$(JobsDBName)",
	"maxSizeBytes": "5368709120",
	"sku": {
		"name": "ElasticPool",
		"tier": "Standard"
	}
}, {
	"name": "$(OrganisationsDBName)",
	"maxSizeBytes": "5368709120",
	"sku": {
		"name": "S12",
		"tier": "Standard"
	}
}]
```